### PR TITLE
```

### DIFF
--- a/quartz-starter/src/main/java/xyz/quartzframework/support/flyway/FlywayConfigurer.java
+++ b/quartz-starter/src/main/java/xyz/quartzframework/support/flyway/FlywayConfigurer.java
@@ -21,7 +21,7 @@ public class FlywayConfigurer {
     @Provide
     @Preferred
     @ActivateWhenBeanPresent(DataSource.class)
-    @ActivateWhenPropertyEquals(value = @Property("${quartz.flyway.enabled:false}"), expected = "true")
+    @ActivateWhenPropertyEquals(expression = "${quartz.flyway.enabled:false}", expected = "true")
     public Flyway flyway(ResourceLoader resourceLoader, DataSource dataSource, FlywayProperties properties) {
         log.info("Enabling Flyway support...");
         Flyway flyway = Flyway.configure(resourceLoader.getClassLoader())


### PR DESCRIPTION
feat: update FlywayConfigurer annotation for property expression (development)

- Modified @ActivateWhenPropertyEquals annotation to use 'expression' instead of 'value' for the 'quartz.flyway.enabled' property.
```